### PR TITLE
Fix and tweak purgecss `content` config

### DIFF
--- a/template-doks/config/postcss.config.js
+++ b/template-doks/config/postcss.config.js
@@ -7,12 +7,9 @@ module.exports = {
     autoprefixer(),
     purgecss({
       content: [
-        './node_modules/@hyas/core/layouts/**/*.html',
-        './node_modules/@hyas/seo/layouts/**/*.html',
-        './node_modules/@hyas/images/layouts/**/*.html',
-        './node_modules/@hyas/doks-core/layouts/**/*.html',
-        './node_modules/@hyas/doks-core/content/**/*.html',
-        './layouts/**/*.html',
+        './node_modules/@hyas/*/layouts/**/*.html',
+        './themes/my-doks-theme/layouts/**/*.html',
+        './content/**/*.html',
         './content/**/*.md',
       ],
       safelist: [


### PR DESCRIPTION
## Summary

Changes to the purgecss `content` config:

- `./node_modules/@hyas/*/layouts/**/*.html` matches all layout files from all `@hyas` packages, thus more future-proof :)
- `./node_modules/@hyas/doks-core/content/` does not exist (doks-core doesn't ship content), thus removed
- main layouts path was wrong (leftover from doks-child-theme?)
- content can be authored in Hugo directly as `.html` files, thus account for that too

## Checks

- [x] Read [Create a Pull Request](https://gethyas.com/docs/contributing/how-to-contribute/#create-a-pull-request)
- [x] Supports all screen sizes (if relevant)
- [x] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test`
