### PR TITLE
Fix config key to toggle KaTeX

### DIFF
--- a/template-doks/config/_default/hyas/doks.toml
+++ b/template-doks/config/_default/hyas/doks.toml
@@ -56,8 +56,8 @@ relatedPosts = false # false (default) or true
 # Footer
 footer = "Powered by <a class=\"text-muted\" href=\"https://www.netlify.com/\">Netlify</a>, <a class=\"text-muted\" href=\"https://gohugo.io/\">Hugo</a>, and <a class=\"text-muted\" href=\"https://getdoks.org/\">Doks</a>"
 
-# kaTex
-kaTex = false
+# KaTex
+katex = false
 
 # Repository
 editPage = false # false (default) or true


### PR DESCRIPTION
## Summary

In the Hugo templates, [it's referred to `katex` (all lowercase)](https://github.com/search?q=repo%3Agethyas%2Fdoks-core+katex+language%3Ahtml&type=code), not `kaTex`. Matching is case-sensitive, thus the current config was broken.

Since the former variant (all lowercase) is easier to remember, we stick with it.

## Checks

- [x] Read [Create a Pull Request](https://gethyas.com/docs/contributing/how-to-contribute/#create-a-pull-request)
- [x] Supports all screen sizes (if relevant)
- [x] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test`
