### PR TITLE
Improve PurgeCSS config

### DIFF
--- a/template-doks/config/_default/hugo.toml
+++ b/template-doks/config/_default/hugo.toml
@@ -19,6 +19,9 @@ defaultContentLanguageInSubdir = false
 
 copyRight = "Copyright (c) 2023 Hyas"
 
+[build.buildStats]
+  enable = true
+
 [social]
   twitter = "getdoks"
 

--- a/template-doks/config/postcss.config.js
+++ b/template-doks/config/postcss.config.js
@@ -6,54 +6,47 @@ module.exports = {
   plugins: [
     autoprefixer(),
     purgecss({
-      content: [
-        './node_modules/@hyas/*/layouts/**/*.html',
-        './themes/*/layouts/**/*.html',
-        './layouts/**/*.html',
-        './content/**/*.html',
-        './content/**/*.md',
+      content: [ './hugo_stats.json' ],
+      extractors: [
+        {
+          extractor: (content) => {
+            const els = JSON.parse(content).htmlElements;
+            return els.tags.concat(els.classes, els.ids);
+          },
+          extensions: ['json']
+        }
+      ],
+      dynamicAttributes: [
+        'aria-expanded',
+        'data-bs-popper',
+        'data-bs-target',
+        'data-bs-theme',
+        'data-dark-mode',
+        'data-global-alert',
+        'data-pane',             // tabs.js
+        'data-popper-placement',
+        'data-sizes',
+        'data-toggle-tab',       // tabs.js
+        'id',
+        'size',
+        'type'
       ],
       safelist: [
-        'lazyloaded',
-        'table',
-        'thead',
-        'tbody',
-        'tr',
-        'th',
-        'td',
-        'h1',
-        'h2',
-        'h3',
-        'h4',
-        'h5',
-        'alert-link',
-        'container-lg',
-        'container-fluid',
-        'offcanvas-backdrop',
-        'img-fluid',
-        'lazyload',
-        'blur-up',
-        'figcaption',
-        'dt',
-        'dd',
-        'showing',
-        'hiding',
+        'active',
+        'btn-clipboard',         // clipboards.js
+        'clipboard',             // clipboards.js
+        'disabled',
+        'hidden',
+        'modal-backdrop',        // search-modal.js
+        'selected',              // search-modal.js
+        'show',
         ...whitelister([
-          './node_modules/@hyas/core/assets/scss/app.scss',
-          './node_modules/@hyas/doks-core/assets/scss/common/_global.scss',
-          './node_modules/@hyas/doks-core/assets/scss/components/_alerts.scss',
-          './node_modules/@hyas/doks-core/assets/scss/components/_buttons.scss',
-          './node_modules/@hyas/doks-core/assets/scss/components/_callouts.scss',
-          './node_modules/@hyas/doks-core/assets/scss/components/_code.scss',
-          // './node_modules/@hyas/doks-core/assets/scss/components/_diagrams.scss',
-          './node_modules/@hyas/doks-core/assets/scss/components/_modals.scss',
-          './node_modules/@hyas/doks-core/assets/scss/components/_syntax.scss',
-          './node_modules/@hyas/doks-core/assets/scss/components/_search.scss',
-          './node_modules/@hyas/doks-core/assets/scss/common/_dark.scss',
-          './node_modules/bootstrap/scss/_dropdown.scss',
-          // './node_modules/katex/dist/katex.css',
-        ]),
-      ],
-    }),
-  ],
+          './assets/scss/**/*.css',
+          './assets/scss/**/*.scss',
+          './node_modules/@hyas/doks-core/assets/scss/common/_custom.scss',
+          './node_modules/katex/dist/katex.css'
+        ])
+      ]
+    })
+  ]
 }

--- a/template-doks/config/postcss.config.js
+++ b/template-doks/config/postcss.config.js
@@ -43,7 +43,6 @@ module.exports = {
         ...whitelister([
           './assets/scss/**/*.css',
           './assets/scss/**/*.scss',
-          './node_modules/@hyas/doks-core/assets/scss/common/_custom.scss',
           './node_modules/katex/dist/katex.css'
         ])
       ]


### PR DESCRIPTION
## Summary

Fixes https://github.com/gethyas/create-hyas/issues/25.

## Notes

- The idea to leverage `dynamicAttributes` was borrowed from [here](https://gethinode.com/guides/optimization/#step-4---purging-unused-css-elements). Having `data-bs-theme` in `dynamicAttributes` ensures *all* the relevant `@include color-mode(...)`  rules are preserved.
- I've replaced most whitelisted style files with more precise `dynamicAttributes` or `safelist` selectors. I've tested quite extensively and hope to have catched all the relevant rules, but I'm not sure. So thorough testing of this PR is very welcome!
- From now on we only need to manually add selectors to the PurgeCSS config when they are dynamically modified (i.e. added via JS). All other selectors should automatically get picked up in `hugo_stats.json`.

## Motivation

Correctness and maintainability.

## Checks

- [x] Read [Create a Pull Request](https://gethyas.com/docs/contributing/how-to-contribute/#create-a-pull-request)
- [x] Supports all screen sizes (if relevant)
- [x] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test`
